### PR TITLE
Implementing an additional arg to the certDP.sh

### DIFF
--- a/scripts/certDP.sh
+++ b/scripts/certDP.sh
@@ -8,6 +8,7 @@ fi
 
 IP=$1
 USER=$2
+PASS=$3
 
 # server.pref
 
@@ -22,8 +23,8 @@ echo "  </preference>" >> server.pref
 echo "  <preference version=\"1\" name=\"com.atakmap.app_preferences\">" >> server.pref
 echo "    <entry key=\"displayServerConnectionWidget\" class=\"class java.lang.Boolean\">true</entry>" >> server.pref
 echo "    <entry key=\"caLocation\" class=\"class java.lang.String\">cert/$IP.p12</entry>" >> server.pref
-echo "    <entry key=\"caPassword\" class=\"class java.lang.String\">atakatak</entry>" >> server.pref
-echo "    <entry key=\"clientPassword\" class=\"class java.lang.String\">atakatak</entry>" >> server.pref
+echo "    <entry key=\"caPassword\" class=\"class java.lang.String\">$PASS</entry>" >> server.pref
+echo "    <entry key=\"clientPassword\" class=\"class java.lang.String\">$PASS</entry>" >> server.pref
 echo "    <entry key=\"certificateLocation\" class=\"class java.lang.String\">cert/$USER.p12</entry>" >> server.pref
 echo "  </preference>" >> server.pref
 echo "</preferences>" >> server.pref


### PR DESCRIPTION
Introduced a third argument ($capass) to the setup.sh script when calling the certDP.sh. Now implementing the logic to handle this argument within the certDP.sh script itself.