### PR TITLE
Read the description - multiple changes to setup.sh

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -326,7 +326,7 @@ while :
 do
 	sleep 10 # let the PG stderr messages conclude...
 	printf $warning "------------CERTIFICATE GENERATION--------------\n"
-	$DOCKER_COMPOSE exec tak bash -c "cd /opt/tak/certs && ./makeRootCa.sh --ca-name CRFtakserver"
+	$DOCKER_COMPOSE exec tak bash -c "cd /opt/tak/certs && ./makeRootCa.sh --ca-name '${cn}'"
 	if [ $? -eq 0 ];
 	then
 		$DOCKER_COMPOSE exec tak bash -c "cd /opt/tak/certs && ./makeCert.sh server $IP"


### PR DESCRIPTION
- Modified the script to request additional DN attributes for certificate generation as per `cert-metadata.sh`.  Let's say if you want to run multiple server e.g., srv1.tak.local
- Adjusted the default values for DN attributes to clarify their intended purpose.
- Updated the script with the option to change the default Certificate Authority (CA) password "atakatak".
- Introduced a third argument ($capass) for the CA password which is passed in the certDP.sh script used for quick setup

Latest change:
The CN (which is the  "$CA_NAME" in makeRootCa.sh) was hardcoded as "CRFtakserver". The "--ca-name" will now be derived from "$cn"